### PR TITLE
Fix `else` level in set_gpu_default_device()

### DIFF
--- a/deepsensor/train/train.py
+++ b/deepsensor/train/train.py
@@ -30,10 +30,10 @@ def set_gpu_default_device():
         # Check GPU visible to tf
         # print("Num GPUs Available: ", len(tf.config.list_physical_devices('GPU')))
 
-        else:
-            raise NotImplementedError(
-                f"Backend {deepsensor.backend.str} not implemented"
-            )
+    else:
+        raise NotImplementedError(
+            f"Backend {deepsensor.backend.str} not implemented"
+        )
 
 
 def train_epoch(


### PR DESCRIPTION
The `else` statement in train.train.set_gpu_default_device() was one indent level too far, mistakenly raising NotImplementedError on TF backend when no GPU is available.