### PR TITLE
Fix rounding errors in `DeepSensorModel.predict` coordinates from normalise-unnormalise operations

### DIFF
--- a/deepsensor/active_learning/algorithms.py
+++ b/deepsensor/active_learning/algorithms.py
@@ -198,7 +198,7 @@ class GreedyAlgorithm:
             infill_ds, _ = self.model.predict(
                 self.tasks,
                 X_s,
-                X_t_normalised=True,
+                X_t_is_normalised=True,
                 unnormalise=False,
                 progress_bar=self.progress_bar >= 4,
             )

--- a/tests/test_data_processor.py
+++ b/tests/test_data_processor.py
@@ -258,30 +258,6 @@ class TestDataProcessor(unittest.TestCase):
         with self.assertRaises(ValueError):
             dp(df_raw)
 
-def test_norm_unnorm_preserves_coords_xr(self):
-    region_size = (61,81)
-    lat_lims = (30,75)
-    lon_lims = (-15,45)
-    
-    latitude = np.linspace(*lat_lims, region_size[0], dtype=np.float32)
-    longitude = np.linspace(*lon_lims, region_size[1], dtype=np.float32)
-    dummy_data = np.random.normal(size=region_size)
-    da_raw = xr.DataArray(dummy_data, dims=['latitude', 'longitude'], coords={'latitude':latitude, 'longitude':longitude})
-
-    data_processor = DataProcessor(
-        x1_name='latitude', x1_map=lat_lims,
-        x2_name='longitude', x2_map=lon_lims
-    )
-
-    da = data_processor(da_raw) # to compute normalisation params
-
-    da_norm = data_processor.map_coords(da_raw)
-    da_unnorm = data_processor.unnormalise(da_norm)
-
-    try:
-        xr.align(da_raw, da_unnorm, join='exact')
-    except ValueError:
-        self.fail('Normalise-unnormalise did not preserve xarray coordinates exactly')
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This adds a unit test which checks that normalising and unnormalising an xarray object with `DataProcessor` (as is done e.g. in `model.predict`) should return the exact same coordinates as the original object. 

This test currently fails, as pointed out in Issue #19 