### PR TITLE
Convert normalization parameters to a dictionary for data processor

### DIFF
--- a/deepsensor/data/processor.py
+++ b/deepsensor/data/processor.py
@@ -323,25 +323,31 @@ class DataProcessor:
         params = self.get_norm_params(var_ID, data, method)
 
         if method == "mean_std":
+            std = params["std"]
+            mean = params["mean"]
             if unnorm:
-                data = data * params["std"]
-                if add_offset:
-                    data = data + params["mean"]
+                scale = std
+                offset = mean
             else:
-                if add_offset:
-                    data = data - params["mean"]
-                data = data / params["std"]
+                scale = 1 / std
+                offset = -mean / std
+            data = data * scale
+            if add_offset:
+                data = data + offset
             return data
 
         elif method == "min_max":
+            minimum = params["min"]
+            maximum = params["max"]
             if unnorm:
-                data = data * (params["max"] - params["min"])
-                if add_offset:
-                    data = data + params["min"]
+                scale = (maximum - minimum) / 2
+                offset = (maximum + minimum) / 2
             else:
-                if add_offset:
-                    data = data - params["min"]
-                data = data / (params["max"] - params["min"])
+                scale = 2 / (maximum - minimum)
+                offset = -(maximum + minimum) / (maximum - minimum)
+            data = data * scale
+            if add_offset:
+                data = data + offset
             return data
 
     def map(


### PR DESCRIPTION
This PR addresses #40.

- Now, we use a parameter dictionary `{"mean": *, "std": *}` for `mean_std` transform and `{"min": *, "max": *}` transform for `min_max` transform in the data processor.
- This does not make any breaking changes to the user-facing API except the type of the output (now a dictionary) while calling `get_norm_params` method:

```py
import xarray as xr
from deepsensor.data.processor import DataProcessor

# load data
ds_raw = xr.tutorial.open_dataset("air_temperature")

# define data processor
data_processor = DataProcessor(
    x1_name="lat", x1_map=(15, 75), x2_name="lon", x2_map=(200, 330)
)

# process data
ds = data_processor(ds_raw, method="mean_std")

# get normalization parameters
data_processor.get_norm_params("air", ds["air"], method="mean_std")
```
Output
```py
{'mean': 281.255126953125, 'std': 16.320409774780273}
```