### PR TITLE
Support non-Gaussian `ConvNP` likelihoods in low-level and high-level prediction interfaces

### DIFF
--- a/deepsensor/model/convnp.py
+++ b/deepsensor/model/convnp.py
@@ -800,8 +800,11 @@ class ConvNP(DeepSensorModel):
     @dispatch
     def logpdf(self, dist: AbstractMultiOutputDistribution, task: Task):
         """
-        Model outputs joint distribution over all targets: Concat targets along
-        observation dimension.
+        Joint logpdf over all target sets.
+
+        .. note::
+            If the model has multiple target sets, the returned logpdf is the
+            mean logpdf over all target sets.
 
         Args:
             dist (neuralprocesses.dist.AbstractMultiOutputDistribution):
@@ -812,14 +815,20 @@ class ConvNP(DeepSensorModel):
         Returns:
             float: The logpdf.
         """
-        Y_t = B.concat(*task["Y_t"], axis=-1)
+        # Need to ensure `Y_t` is a tensor and, if multiple target sets,
+        #   an nps.Aggregate object
+        task = ConvNP.modify_task(task)
+        _, _, Y_t, _ = convert_task_to_nps_args(task)
         return B.to_numpy(dist.logpdf(Y_t)).mean()
 
     @dispatch
     def logpdf(self, task: Task):
         """
-        Model outputs joint distribution over all targets: Concat targets along
-        observation dimension.
+        Joint logpdf over all target sets.
+
+        .. note::
+            If the model has multiple target sets, the returned logpdf is the
+            mean logpdf over all target sets.
 
         Args:
             task (:class:`~.data.task.Task`):

--- a/deepsensor/model/convnp.py
+++ b/deepsensor/model/convnp.py
@@ -450,7 +450,7 @@ class ConvNP(DeepSensorModel):
         return self.variance(dist)
 
     @dispatch
-    def stddev(self, dist: AbstractMultiOutputDistribution):
+    def std(self, dist: AbstractMultiOutputDistribution):
         """
         ...
 
@@ -468,7 +468,7 @@ class ConvNP(DeepSensorModel):
             return np.sqrt(variance)
 
     @dispatch
-    def stddev(self, task: Task):
+    def std(self, task: Task):
         """
         ...
 
@@ -480,7 +480,7 @@ class ConvNP(DeepSensorModel):
             ...: ...
         """
         dist = self(task)
-        return self.stddev(dist)
+        return self.std(dist)
 
     @dispatch
     def covariance(self, dist: AbstractMultiOutputDistribution):

--- a/deepsensor/model/convnp.py
+++ b/deepsensor/model/convnp.py
@@ -497,21 +497,13 @@ class ConvNP(DeepSensorModel):
         return self.std(dist)
 
     @dispatch
-    def beta_dist_alpha(self, dist: AbstractMultiOutputDistribution):
-        """
-        Alpha parameter of a Beta distribution
-        https://www.wikipedia.com/en/Beta_distribution
-
-        Args:
-            dist (neuralprocesses.dist.AbstractMultiOutputDistribution):
-                ...
-
-        Returns:
-            ...: ...
-        """
-        if self.config["likelihood"] not in ["spikes-beta"]:
+    def alpha(
+        self, dist: AbstractMultiOutputDistribution
+    ) -> Union[np.ndarray, List[np.ndarray]]:
+        if self.config["likelihood"] not in ["spikes-beta", "bernoulli-gamma"]:
             raise NotImplementedError(
-                f"beta_dist_alpha not supported for likelihood {self.config['likelihood']}"
+                f"ConvNP.alpha method not supported for likelihood {self.config['likelihood']}. "
+                f"Try changing the likelihood to a mixture model, e.g. 'spikes-beta' or 'bernoulli-gamma'."
             )
         alpha = dist.slab.alpha
         if isinstance(alpha, backend.nps.Aggregate):
@@ -520,36 +512,31 @@ class ConvNP(DeepSensorModel):
             return B.to_numpy(alpha)[0, 0]
 
     @dispatch
-    def beta_dist_alpha(self, task: Task):
+    def alpha(self, task: Task) -> Union[np.ndarray, List[np.ndarray]]:
         """
-        ...
+        Alpha values of model's distribution at target locations in task.
+
+        .. note::
+            This method only works for models that return a distribution with
+            a ``dist.slab.alpha`` attribute, e.g. models with a Beta or
+            Bernoulli-Gamma likelihood.
 
         Args:
             task (:class:`~.data.task.Task`):
-                ...
+                The task containing the context and target data.
 
         Returns:
-            ...: ...
+            Union[np.ndarray, List[np.ndarray]]: Alpha values.
         """
         dist = self(task)
-        return self.beta_dist_alpha(dist)
+        return self.alpha(dist)
 
     @dispatch
-    def beta_dist_beta(self, dist: AbstractMultiOutputDistribution):
-        """
-        Beta parameter of a Beta distribution
-        https://www.wikipedia.com/en/Beta_distribution
-
-        Args:
-            dist (neuralprocesses.dist.AbstractMultiOutputDistribution):
-                ...
-
-        Returns:
-            ...: ...
-        """
-        if self.config["likelihood"] not in ["spikes-beta"]:
+    def beta(self, dist: AbstractMultiOutputDistribution):
+        if self.config["likelihood"] not in ["spikes-beta", "bernoulli-gamma"]:
             raise NotImplementedError(
-                f"beta_dist_beta not supported for likelihood {self.config['likelihood']}"
+                f"ConvNP.beta method not supported for likelihood {self.config['likelihood']}. "
+                f"Try changing the likelihood to a mixture model, e.g. 'spikes-beta' or 'bernoulli-gamma'."
             )
         beta = dist.slab.beta
         if isinstance(beta, backend.nps.Aggregate):
@@ -558,19 +545,24 @@ class ConvNP(DeepSensorModel):
             return B.to_numpy(beta)[0, 0]
 
     @dispatch
-    def beta_dist_beta(self, task: Task):
+    def beta(self, task: Task):
         """
-        ...
+        Beta values of model's distribution at target locations in task.
+
+        .. note::
+            This method only works for models that return a distribution with
+            a ``dist.slab.beta`` attribute, e.g. models with a Beta or
+            Bernoulli-Gamma likelihood.
 
         Args:
             task (:class:`~.data.task.Task`):
-                ...
+                The task containing the context and target data.
 
         Returns:
-            ...: ...
+            Union[np.ndarray, List[np.ndarray]]: Beta values.
         """
         dist = self(task)
-        return self.beta_dist_beta(dist)
+        return self.beta(dist)
 
     @dispatch
     def mixture_probs(self, dist: AbstractMultiOutputDistribution):

--- a/deepsensor/model/convnp.py
+++ b/deepsensor/model/convnp.py
@@ -516,7 +516,6 @@ class ConvNP(DeepSensorModel):
         self,
         dist: AbstractMultiOutputDistribution,
         n_samples: int = 1,
-        noiseless: bool = True,
     ):
         """
         Create samples from a ConvNP distribution.
@@ -527,15 +526,12 @@ class ConvNP(DeepSensorModel):
             n_samples (int, optional):
                 The number of samples to draw from the distribution, by
                 default 1.
-            noiseless (bool, optional):
-                Whether to sample from the noiseless distribution, by default
-                True.
 
         Returns:
             :class:`numpy:numpy.ndarray` | List[:class:`numpy:numpy.ndarray`]:
                 The samples as an array or list of arrays.
         """
-        if noiseless:
+        if self.config["likelihood"] in ["gnp", "lowrank"]:
             samples = dist.noiseless.sample(n_samples)
         else:
             samples = dist.sample(n_samples)
@@ -546,7 +542,7 @@ class ConvNP(DeepSensorModel):
             return B.to_numpy(samples)[:, 0, 0]
 
     @dispatch
-    def sample(self, task: Task, n_samples: int = 1, noiseless: bool = True):
+    def sample(self, task: Task, n_samples: int = 1):
         """
         Create samples from a ConvNP distribution.
 
@@ -556,16 +552,13 @@ class ConvNP(DeepSensorModel):
             n_samples (int, optional):
                 The number of samples to draw from the distribution, by
                 default 1.
-            noiseless (bool, optional):
-                Whether to sample from the noiseless distribution, by default
-                True.
 
         Returns:
             :class:`numpy:numpy.ndarray` | List[:class:`numpy:numpy.ndarray`]:
                 The samples as an array or list of arrays.
         """
         dist = self(task)
-        return self.sample(dist, n_samples, noiseless)
+        return self.sample(dist, n_samples)
 
     @dispatch
     def slice_diag(self, task: Task):

--- a/deepsensor/model/convnp.py
+++ b/deepsensor/model/convnp.py
@@ -526,7 +526,8 @@ class ConvNP(DeepSensorModel):
                 The task containing the context and target data.
 
         Returns:
-            Union[np.ndarray, List[np.ndarray]]: Alpha values.
+            :class:`numpy:numpy.ndarray` | List[:class:`numpy:numpy.ndarray`]:
+                Alpha values.
         """
         dist = self(task)
         return self.alpha(dist)
@@ -559,7 +560,8 @@ class ConvNP(DeepSensorModel):
                 The task containing the context and target data.
 
         Returns:
-            Union[np.ndarray, List[np.ndarray]]: Beta values.
+            :class:`numpy:numpy.ndarray` | List[:class:`numpy:numpy.ndarray`]:
+                Beta values.
         """
         dist = self(task)
         return self.beta(dist)

--- a/deepsensor/model/convnp.py
+++ b/deepsensor/model/convnp.py
@@ -222,6 +222,7 @@ class ConvNP(DeepSensorModel):
             kwargs["decoder_scale"] = decoder_scale
 
         self.model, self.config = construct_neural_process(*args, **kwargs)
+        self._set_num_mixture_components()
 
     @dispatch
     def __init__(
@@ -254,6 +255,7 @@ class ConvNP(DeepSensorModel):
         super().__init__()
 
         self.load(model_ID)
+        self._set_num_mixture_components()
 
     @dispatch
     def __init__(
@@ -277,6 +279,18 @@ class ConvNP(DeepSensorModel):
         super().__init__(data_processor, task_loader)
 
         self.load(model_ID)
+        self._set_num_mixture_components()
+
+    def _set_num_mixture_components(self):
+        """
+        Set the number of mixture components for the model based on the likelihood.
+        """
+        if self.config["likelihood"] in ["spikes-beta"]:
+            self.N_mixture_components = 3
+        elif self.config["likelihood"] in ["bernoulli-gamma"]:
+            self.N_mixture_components = 2
+        else:
+            self.N_mixture_components = 1
 
     def save(self, model_ID: str):
         """

--- a/deepsensor/model/model.py
+++ b/deepsensor/model/model.py
@@ -510,8 +510,8 @@ class DeepSensorModel(ProbabilisticModel):
                 try:
                     method = getattr(self, param)
                     prediction_methods[param] = method
-                except ValueError:
-                    raise ValueError(
+                except AttributeError:
+                    raise AttributeError(
                         f"Prediction method {param} not found in model class."
                     )
             if n_samples >= 1:

--- a/deepsensor/model/model.py
+++ b/deepsensor/model/model.py
@@ -23,7 +23,6 @@ import pandas as pd
 import xarray as xr
 import lab as B
 
-
 # For dispatching with TF and PyTorch model types when they have not yet been loaded.
 # See https://beartype.github.io/plum/types.html#moduletype
 
@@ -71,7 +70,7 @@ class ProbabilisticModel:
         """
         raise NotImplementedError()
 
-    def stddev(self, task: Task):
+    def std(self, task: Task):
         """
         Model marginal standard deviation over target points given context
         points. Shape (N,).
@@ -85,6 +84,9 @@ class ProbabilisticModel:
         """
         var = self.variance(task)
         return var**0.5
+
+    def stddev(self, *args, **kwargs):
+        return self.std(*args, **kwargs)
 
     def covariance(self, task: Task, *args, **kwargs):
         """

--- a/deepsensor/model/model.py
+++ b/deepsensor/model/model.py
@@ -217,6 +217,8 @@ class DeepSensorModel(ProbabilisticModel):
             TaskLoader object, used to determine target variables for unnormalising.
     """
 
+    N_mixture_components = 1  # Number of mixture components for mixture likelihoods
+
     def __init__(
         self,
         data_processor: Optional[DataProcessor] = None,

--- a/deepsensor/model/nps.py
+++ b/deepsensor/model/nps.py
@@ -237,6 +237,8 @@ def construct_neural_process(
         likelihood = "lowrank"
     elif likelihood == "cnp-spikes-beta":
         likelihood = "spikes-beta"
+    elif likelihood == "cnp-bernoulli-gamma":
+        likelihood = "bernoulli-gamma"
 
     # Log the call signature for `construct_convgnp`
     config = dict(locals())

--- a/deepsensor/plot.py
+++ b/deepsensor/plot.py
@@ -309,7 +309,7 @@ def offgrid_context(
     context coordinates if provided.
 
     Args:
-        axes (:class:`numpy:numpy.ndarray` | List[:class:`matplotlib:matplotlib.axes.Axes`] | Tuple[:class:`matplotlib:matplotlib.axes.Axes`]:
+        axes (:class:`numpy:numpy.ndarray` | List[:class:`matplotlib:matplotlib.axes.Axes`] | Tuple[:class:`matplotlib:matplotlib.axes.Axes`]):
             Axes to plot on.
         task (:class:`~.data.task.Task`):
             Task containing the context set to plot.

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -69,6 +69,7 @@ sphinx:
     autodoc_typehints: "none"
     autoclass_content: "class"
     bibtex_reference_style: author_year
+    napoleon_use_rtype: False
     intersphinx_mapping:
       python:
         - https://docs.python.org/3

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -131,11 +131,10 @@ class TestModel(unittest.TestCase):
             )
 
             for target_sampling, expected_obs_shape in (
-                (10, (10,)),  # expected shape is (10,) when target_sampling is 10
-                (
-                    "all",
-                    self.da.shape[-2:],
-                ),  # expected shape is da.shape[-2:] when target_sampling is "all"
+                # expected shape is (10,) when target_sampling is 10
+                (10, (10,)),
+                # expected shape is da.shape[-2:] when target_sampling is "all"
+                ("all", self.da.shape[-2:]),
             ):
                 task = tl("2020-01-01", context_sampling, target_sampling)
 
@@ -143,7 +142,7 @@ class TestModel(unittest.TestCase):
 
                 # Tensors
                 mean = model.mean(task)
-                # TODO avoid repeated code
+                # TODO avoid repeated code by looping over methods
                 if isinstance(mean, (list, tuple)):
                     for m, dim_y in zip(mean, tl.target_dims):
                         assert_shape(m, (dim_y, *expected_obs_shape))
@@ -222,12 +221,12 @@ class TestModel(unittest.TestCase):
                 # Scalars
                 if likelihood in ["cnp", "gnp"]:
                     # Methods for Gaussian likelihoods only
-                    x = model.logpdf(task)
-                    assert x.size == 1 and x.shape == ()
                     x = model.joint_entropy(task)
                     assert x.size == 1 and x.shape == ()
                     x = model.mean_marginal_entropy(task)
                     assert x.size == 1 and x.shape == ()
+                x = model.logpdf(task)
+                assert x.size == 1 and x.shape == ()
                 x = B.to_numpy(model.loss_fn(task))
                 assert x.size == 1 and x.shape == ()
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -204,14 +204,14 @@ class TestModel(unittest.TestCase):
                             ),
                         )
 
-                    x = model.beta_dist_alpha(task)
+                    x = model.alpha(task)
                     if isinstance(x, (list, tuple)):
                         for p, dim_y in zip(x, tl.target_dims):
                             assert_shape(p, (dim_y, *expected_obs_shape))
                     else:
                         assert_shape(x, (n_target_sets, *expected_obs_shape))
 
-                    x = model.beta_dist_beta(task)
+                    x = model.beta(task)
                     if isinstance(x, (list, tuple)):
                         for p, dim_y in zip(x, tl.target_dims):
                             assert_shape(p, (dim_y, *expected_obs_shape))

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -438,16 +438,44 @@ class TestModel(unittest.TestCase):
         )
 
     def test_highlevel_predict_with_pred_params(self):
-        """Test that passing ``pred_params`` to ``.predict`` works."""
+        """
+        Test that passing ``pred_params`` to ``.predict`` works with
+        a spikes-beta likelihood.
+        """
         tl = TaskLoader(context=self.da, target=self.da)
-        model = ConvNP(self.dp, tl, unet_channels=(5, 5, 5), verbose=False)
+        model = ConvNP(
+            self.dp,
+            tl,
+            unet_channels=(5, 5, 5),
+            verbose=False,
+            likelihood="cnp-spikes-beta",
+        )
         task = tl("2020-01-01", context_sampling=10, target_sampling=10)
 
         # Check that nothing breaks and the correct parameters are returned
-        pred_params = ["mean", "std", "variance"]
+        pred_params = ["mean", "std", "variance", "alpha", "beta"]
         pred = model.predict(task, X_t=self.da, pred_params=pred_params)
         for pred_param in pred_params:
             assert pred_param in pred["var"]
+
+        # Test mixture probs special case
+        pred_params = ["mixture_probs"]
+        pred = model.predict(task, X_t=self.da, pred_params=pred_params)
+        for component in range(model.N_mixture_components):
+            pred_param = f"mixture_probs_{component}"
+            assert pred_param in pred["var"]
+
+    def test_highlevel_predict_with_invalid_pred_params(self):
+        """Test that passing ``pred_params`` to ``.predict`` works."""
+        tl = TaskLoader(context=self.da, target=self.da)
+        model = ConvNP(
+            self.dp,
+            tl,
+            unet_channels=(5, 5, 5),
+            verbose=False,
+            likelihood="cnp-spikes-beta",
+        )
+        task = tl("2020-01-01", context_sampling=10, target_sampling=10)
 
         # Check that passing an invalid parameter raises an AttributeError
         with self.assertRaises(AttributeError):

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -448,10 +448,10 @@ class TestModel(unittest.TestCase):
         pred_params = ["mean", "std", "variance"]
         pred = model.predict(task, X_t=self.da, pred_params=pred_params)
         for pred_param in pred_params:
-            assert pred_param in pred["air"]
+            assert pred_param in pred["var"]
 
-        # Check that passing an invalid parameter raises a ValueError
-        with self.assertRaises(ValueError):
+        # Check that passing an invalid parameter raises an AttributeError
+        with self.assertRaises(AttributeError):
             model.predict(task, X_t=self.da, pred_params=["invalid_param"])
 
     def test_saving_and_loading(self):


### PR DESCRIPTION
Closes https://github.com/tom-andersson/deepsensor/issues/95

Here's an example using the "spikes-beta" CNP likelihood from @wesselb's neuralprocesses, which is a mixture likelihood with deltas/spikes at 0 and 1 and a Beta distribution in (0, 1):

```
>>> # Vanilla DeepSensor quickstart code here...
>>> model = ConvNP(data_processor, task_loader, likelihood="cnp-spikes-beta")
>>> pred = model.predict(test_task, X_t=ds_raw, pred_params=["mean", "std", "beta_dist_alpha", "beta_dist_beta", "mixture_probs"])
>>> pred
{'air': <xarray.Dataset>
Dimensions:          (time: 1, lat: 25, lon: 53)
Coordinates:
  * lat              (lat) float32 75.0 72.5 70.0 67.5 ... 22.5 20.0 17.5 15.0
  * lon              (lon) float32 200.0 202.5 205.0 207.5 ... 325.0 327.5 330.0
  * time             (time) datetime64[ns] 2014-12-31
Data variables:
    mean             (time, lat, lon) float32 290.2 290.2 290.2 ... 290.4 290.3
    std              (time, lat, lon) float32 7.688 7.686 7.686 ... 7.679 7.685
    beta_dist_alpha  (time, lat, lon) float32 0.4868 0.4867 ... 0.4859 0.4845
    beta_dist_beta   (time, lat, lon) float32 0.6727 0.6681 ... 0.668 0.6739
    mixture_probs_0  (time, lat, lon) float32 0.4646 0.4641 ... 0.4794 0.4716
    mixture_probs_1  (time, lat, lon) float32 0.338 0.3375 ... 0.3292 0.3335
    mixture_probs_2  (time, lat, lon) float32 0.1975 0.1984 ... 0.1914 0.1949}
```
Above, you can see the three mixture probabilities as well as the alpha and beta parameters of the Beta component in the Prediction object.

Under the hood, the new pred_params kwarg of model.predict dictates which low-level model methods get called and have their outputs stored in the Prediction object (the default is ["mean", "std"]).

I've added three new methods to the ConvNP class: beta_dist_alpha, beta_dist_beta, and mixture_probs, each returning parameters of a neuralprocesses distribution object using dist.slab.alpha, dist.slab.beta, and dist.logprobs, respectively.

Will update as necessary when the Bernoulli-Gamma likelihood becomes available in `neuralprocesses`.