### PR TITLE
Minor suggestions to installation docs.

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -12,6 +12,10 @@ This is the easiest way to install DeepSensor.
 pip install deepsensor
 ```
 
+```{note}
+We advise installing DeepSensor and its dependencies in a python virtual environment using a tool such as [venv](https://docs.python.org/3/library/venv.html) or [conda](https://conda.io/projects/conda/en/latest/user-guide/getting-started.html#managing-python) (other virtual environment managers are available).
+```
+
 ## Install DeepSensor from [source](https://github.com/tom-andersson/deepsensor)
 
 ```{note}

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -31,7 +31,7 @@ This method will create a `DeepSensor` directory on your machine which will cont
 - Install `DeepSensor`:
 
   ```bash
-  pip install -e -v .
+  pip install -v -e .
   ```
 ## Install PyTorch or TensorFlow
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -25,7 +25,7 @@ This method will create a `DeepSensor` directory on your machine which will cont
 - Clone the repository:
 
   ```bash
-  git clone
+  git clone https://github.com/tom-andersson/deepsensor
   ```
 
 - Install `DeepSensor`:


### PR DESCRIPTION
Hi folks, just a couple of minor suggestions to the installation docs, feel free to close if wrong or not required!

This pr:
* Adds repo url to `git clone` command to make more explicit for any new git users - appreciate that this may have been a deliberate choice so feel free to edit or reject.
* Reorders options for editable pip install from `pip install -e -v .` to `pip install -v -e .` since the first arg after `-e` is taken as the install source, meaning the first example fails (at least with pip v 23.3.1),
* Adds a note advising virtual environments, this may just be a personal preference for python project install docs, so can remove if you're not keen.

Thx! This looks like a great project! :rocket: 