### PR TITLE
Remove product manager email from contact info

### DIFF
--- a/docs/contact.md
+++ b/docs/contact.md
@@ -3,4 +3,3 @@
 If you would like to contact us directly, please loop in everyone on the core team:
 
 * Lead developer: tomandersson3@gmail.com
-* Product manager: kwesterling@turing.ac.uk


### PR DESCRIPTION
Resolves #159 

Kalle has left Turing (some time ago).