### PR TITLE
Release management & python version support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.9', '3.13']
 
     steps:
     - uses: actions/checkout@v6
@@ -28,10 +28,9 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install .[dev,testing]
-        pip install tox-gh-actions
-    - name: Test with tox
-      run: tox
+        pip install .[test,tf,torch]
+    - name: Test with pytest
+      run: pytest
     - name: Run coveralls
       run: coveralls --service=github
       env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,12 +13,12 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.8', '3.11']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - name: Free Disk Space (Ubuntu)

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -38,5 +38,5 @@ keywords:
   - neural processes
   - active learning
 license: MIT
-version: 0.4.2
-date-released: '2024-10-20'
+version: 0.4.3
+date-released: '2026-05-06'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -257,7 +257,7 @@ Note that these instructions are intended for the maintainers of DeepSensor.
 
 ## Release Management
 
-1. Bump the version manually in the files: `pyproject.toml` and `CITATION.cff`.
+1. Bump the version manually in `CITATION.cff`, including the release date.
 1. Draft a new release and create a new tag with the same new version name, e.g. v0.4.3.
 1. Click 'Generate release notes' and it will automatically fill the release notes based on the commit history between HEAD and the previous release. Delete most of the individual commit messages which are way too granular, and replace them with higher-level updates.
 1. Ensure this is set as the new version (which is on by default), and publish the release. You should see the publish action start to run [here](https://github.com/alan-turing-institute/deepsensor/actions/workflows/publish.yml), and when it completes the PyPI server and website will be updated with the new version.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -251,6 +251,17 @@ familiarize yourself with our Code of Conduct that lists the expected behaviours
 Every contributor is expected to adhere to our Code of Conduct. It outlines our expectations and
 ensures a safe, respectful environment for everyone.
 
+# Maintenance
+
+Note that these instructions are intended for the maintainers of DeepSensor.
+
+## Release Management
+
+1. Bump the version manually in the files: `pyproject.toml` and `CITATION.cff`.
+1. Draft a new release and create a new tag with the same new version name, e.g. v0.4.3.
+1. Click 'Generate release notes' and it will automatically fill the release notes based on the commit history between HEAD and the previous release. Delete most of the individual commit messages which are way too granular, and replace them with higher-level updates.
+1. Ensure this is set as the new version (which is on by default), and publish the release. You should see the publish action start to run [here](https://github.com/alan-turing-institute/deepsensor/actions/workflows/publish.yml), and when it completes the PyPI server and website will be updated with the new version.
+
 ----
 
 These Contributing Guidelines have been adapted from

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ data with neural processes</p>
 
 -----------
 
-[![release](https://img.shields.io/badge/release-v0.4.2-green?logo=github)](https://github.com/alan-turing-institute/deepsensor/releases)
+[![release](https://img.shields.io/github/v/release/alan-turing-institute/deepsensor?display_name=release&logo=github&color=green)](https://github.com/alan-turing-institute/deepsensor/releases)
 [![Latest Docs](https://img.shields.io/badge/docs-latest-blue.svg)](https://alan-turing-institute.github.io/deepsensor/)
 ![Tests](https://github.com/alan-turing-institute/deepsensor/actions/workflows/tests.yml/badge.svg)
 [![Coverage Status](https://coveralls.io/repos/github/alan-turing-institute/deepsensor/badge.svg?branch=main)](https://coveralls.io/github/alan-turing-institute/deepsensor?branch=main)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Operating System :: OS Independent"
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
     "backends>=1.7.0",
     "backends-matrix",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["setuptools>=61"]
+requires = ["setuptools>=80", "setuptools-scm[simple]>=9.2"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "deepsensor"
-version = "0.4.2"
+dynamic = ["version"]
 authors = [
     {name = "Tom R. Andersson", email="tomandersson3@gmail.com"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,10 +45,7 @@ Bug_Tracker = "https://github.com/alan-turing-institute/deepsensor/issues"
 torch = ["torch>=2"]
 tf = ["tensorflow", "tensorflow_probability[tf]"]
 dev = [
-    "coveralls",
-    "parameterized",
     "pre-commit",
-    "pytest",
     "ruff",
 ]
 docs = [
@@ -57,7 +54,8 @@ docs = [
     "numpy",
     "sphinx",
 ]
-testing = [
+test = [
+    "coveralls",
     "mypy",
     "parameterized",
     "pytest",

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,6 @@ python =
 setenv =
     PYTHONPATH = {toxinidir}
 deps =
-    .[tf,torch,testing]
+    .[dev,testing]
 commands =
     pytest --basetemp={envtmpdir}

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,6 @@ python =
 setenv =
     PYTHONPATH = {toxinidir}
 deps =
-    .[dev,testing]
+    .[tf,torch,test]
 commands =
     pytest --basetemp={envtmpdir}


### PR DESCRIPTION
+ Add release management instructions,
+ Use dynamic versioning, resolves #168 
+ Automate formatting of release badge in readme.
+ Testing with python 3.9 & 3.13 - 3.14 not supported by tensorflow yet weirdly, will review in future.