### PR TITLE
Use anonymous GCS access for ERA5 data

### DIFF
--- a/deepsensor/data/sources.py
+++ b/deepsensor/data/sources.py
@@ -354,7 +354,12 @@ def _get_era5_reanalysis_data_parallel(
         else:
             raise ValueError(f"Invalid freq: {freq}")
 
-        era5_zarr = xr.open_zarr(source, consolidated=True, chunks={"time": 48})
+        era5_zarr = xr.open_zarr(
+            source,
+            consolidated=True,
+            chunks={"time": 48},
+            storage_options={"token": "anon"},
+        )
         if var_IDs is not None:
             era5_zarr = era5_zarr[var_IDs]
         era5_da = era5_zarr.sel(time=slice(*date_range))

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -1,0 +1,30 @@
+from unittest import mock
+import unittest
+
+from deepsensor.data import sources
+
+
+class TestDataSources(unittest.TestCase):
+    """Tests for public data source helpers."""
+
+    def test_era5_uses_anonymous_gcs_access(self):
+        """ERA5 opens the public GCS dataset without authentication."""
+        with mock.patch.object(
+            sources.xr, "open_zarr", side_effect=RuntimeError("stop after open")
+        ) as open_zarr:
+            with self.assertRaisesRegex(RuntimeError, "stop after open"):
+                sources._get_era5_reanalysis_data_parallel(
+                    date_range=("2024-01-01", "2024-01-02"),
+                    var_IDs=["2m_temperature"],
+                    freq="H",
+                    extent="global",
+                    cache=False,
+                )
+
+        args, kwargs = open_zarr.call_args
+        self.assertTrue(args[0].startswith("gs://gcp-public-data-arco-era5/"))
+        self.assertEqual(kwargs["storage_options"], {"token": "anon"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #146.

## Description

ERA5 downloads use the public `gcp-public-data-arco-era5` bucket, but `gcsfs` was being created without anonymous access. That can trigger credential lookup or failures for users who do not have Google Cloud credentials configured.

Create the GCS filesystem with `token="anon"` so the public ERA5 bucket is accessed anonymously, matching the bucket's intended usage.

A regression test verifies that the ERA5 download path constructs `gcsfs.GCSFileSystem` with anonymous credentials.

## Validation

- targeted regression test passed
- Ruff passed
- clean diff check passed