### PR TITLE
Fix prediction resolution-factor resampling

### DIFF
--- a/deepsensor/model/pred.py
+++ b/deepsensor/model/pred.py
@@ -332,7 +332,8 @@ def increase_spatial_resolution(
     if coord_names is None:
         coord_names = {"x1": "x1", "x2": "x2"}
     x1_name, x2_name = coord_names["x1"], coord_names["x2"]
-    x1, x2 = X_t_normalised.coords[x1_name], X_t_normalised.coords[x2_name]
+    x1 = X_t_normalised.coords[x1_name].to_numpy()
+    x2 = X_t_normalised.coords[x2_name].to_numpy()
     x1 = np.linspace(x1[0], x1[-1], int(x1.size * resolution_factor), dtype="float64")
     x2 = np.linspace(x2[0], x2[-1], int(x2.size * resolution_factor), dtype="float64")
     X_t_normalised = X_t_normalised.interp(

--- a/tests/test_pred.py
+++ b/tests/test_pred.py
@@ -1,0 +1,31 @@
+import unittest
+
+import numpy as np
+import xarray as xr
+
+from deepsensor.model.pred import increase_spatial_resolution
+
+
+class TestPredictionHelpers(unittest.TestCase):
+    def test_increase_spatial_resolution_with_xarray_coords(self):
+        data = xr.DataArray(
+            np.arange(24).reshape(4, 6),
+            coords={
+                "x1": np.linspace(0.0, 1.0, 4),
+                "x2": np.linspace(10.0, 20.0, 6),
+            },
+            dims=("x1", "x2"),
+        )
+
+        for xarray_obj in (data, data.to_dataset(name="value")):
+            with self.subTest(type=type(xarray_obj).__name__):
+                result = increase_spatial_resolution(xarray_obj, 0.5)
+
+                self.assertEqual(result.sizes["x1"], 2)
+                self.assertEqual(result.sizes["x2"], 3)
+                np.testing.assert_allclose(result.x1, [0.0, 1.0])
+                np.testing.assert_allclose(result.x2, [10.0, 15.0, 20.0])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #167.

`increase_spatial_resolution` passes scalar xarray coordinate elements directly to `np.linspace`. With current NumPy/xarray this can fail while constructing the new grid, which breaks the `resolution_factor` path for on-grid predictions.

Convert the x1/x2 coordinate arrays to NumPy before computing the resampled coordinates. This preserves the existing interpolation behavior while ensuring `np.linspace` receives ordinary NumPy arrays.

The regression test covers both `xarray.DataArray` and `xarray.Dataset` inputs and verifies that a 0.5 resolution factor produces the expected 2x3 grid.

Validation:
- reproduced the original failure locally with current NumPy/xarray
- patched behavior produced the expected coordinates for DataArray and Dataset inputs
- fork docs and style checks passed
- Python 3.13 full-suite CI hits the same exit-139 failure already present on upstream `main`; Python 3.9 is cancelled by matrix fail-fast after that baseline failure

Opened as Draft pending upstream CI/review.